### PR TITLE
Add new APIs for getting the context from a decoder and clearing the error in a context

### DIFF
--- a/Sources/ZippyJSONCFamily/JSONSerialization.mm
+++ b/Sources/ZippyJSONCFamily/JSONSerialization.mm
@@ -70,8 +70,17 @@ public:
     }
 };
 
+ContextPointer JNTContextFromDecoder(DecoderPointer decoder) {
+    return decoder->context;
+}
+
 bool JNTErrorDidOccur(ContextPointer context) {
     return context->error.type != JNTDecodingErrorTypeNone;
+}
+
+void JNTClearError(ContextPointer context) {
+    if (!context) { return; }
+    context->error.type = JNTDecodingErrorTypeNone;
 }
 
 void JNTProcessError(ContextPointer context, void (^block)(const char *description, JNTDecodingErrorType type, DecoderPointer value, const char *key)) {

--- a/Sources/ZippyJSONCFamily/include/JSONSerialization_Private.h
+++ b/Sources/ZippyJSONCFamily/include/JSONSerialization_Private.h
@@ -40,7 +40,9 @@ ContextPointer JNTCreateContext(const char *negInfString, const char *posInfStri
 DecoderPointer JNTDocumentFromJSON(ContextPointer context, const void *data, NSInteger length, bool convertCase, const char * *retryReason, bool fullPrecisionFloatParsing);
 BOOL JNTDocumentContains(DecoderPointer iterator, const char *key);
 void JNTProcessError(ContextPointer context, void (^block)(const char *description, JNTDecodingErrorType type, DecoderPointer value, const char *key));
+ContextPointer JNTContextFromDecoder(DecoderPointer decoder);
 bool JNTErrorDidOccur(ContextPointer context);
+void JNTClearError(ContextPointer context);
 BOOL JNTDocumentDecodeNil(DecoderPointer documentPtr);
 void JNTReleaseContext(ContextPointer context);
 DecoderPointer JNTDocumentFromJSON(ContextPointer context, const void *data, NSInteger length, bool convertCase, const char * *retryReason, bool fullPrecisionFloatParsing);


### PR DESCRIPTION
Hey there! I started working on a fix for https://github.com/michaeleisel/ZippyJSON/issues/12, and in order to do that I needed a couple of new APIs exposed in the C family library. I'll open a PR in the main repo for this soon.

Happy to take any feedback on this, or if there's another way to get the context from a DecoderPointer or reset the context's error, let me know 👍